### PR TITLE
Make the in_array check strict to fix recusion issues with objects.

### DIFF
--- a/src/Set.php
+++ b/src/Set.php
@@ -26,7 +26,7 @@ class Set extends AbstractList {
 	 * @return $this
 	 */
 	public function add($element) {
-		if (!in_array($element, $this->collection)) {
+		if (!in_array($element, $this->collection, true)) {
 			$this->collection[$this->size()] = $element;
 		}
 

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -2,6 +2,7 @@
 namespace phootwork\collection\tests;
 
 use phootwork\collection\Set;
+use phootwork\collection\tests\fixtures\Item;
 
 class SetTest extends \PHPUnit_Framework_TestCase {
 	
@@ -82,5 +83,22 @@ class SetTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($set->toArray(), $clone->toArray());
 		$this->assertNotSame($set, $clone);
 	}
-	
+
+    /**
+     * Test item recursion issues.
+     */
+	public function testAddRecursion()
+    {
+        $item1 = new Item();
+        $item2 = new Item($item1);
+        $item1->setContent($item2);
+
+        $set = new Set();
+        $set
+            ->add($item1)
+            ->add($item2);
+        ;
+
+        $this->assertEquals(2, $set->size());
+    }
 }


### PR DESCRIPTION
The current `Set::add` method using a non strict version of `in_array`. This method when used with objects in non-strict mode will attempt to traverse objects to evaluate truthiness. This can create an issue if the objects are of any complexity and cause a [recursion error][1]. This PR makes those strict, which will also be better for other data types, since generally speaking Set's are used with specific types of data anyway.

[1]: https://stackoverflow.com/questions/8460011/in-array-on-objects-with-circular-references#answer-8460312