### PR TITLE
Move `get` and `indexOf` methods

### DIFF
--- a/src/AbstractList.php
+++ b/src/AbstractList.php
@@ -124,4 +124,27 @@ abstract class AbstractList extends AbstractCollection {
 	
 		return $index;
 	}
+
+    /**
+     * Returns the element at the given index (or nothing if the index isn't present)
+     *
+     * @param int $index
+     * @return mixed
+     */
+    public function get($index) {
+        if (isset($this->collection[$index])) {
+            return $this->collection[$index];
+        }
+    }
+
+    /**
+     * Returns the index of the given element or FALSE if the element can't be found
+     *
+     * @param mixed $element
+     * @return int the index for the given element
+     */
+    public function indexOf($element) {
+        return array_search($element, $this->collection, true);
+    }
+
 }

--- a/src/ArrayList.php
+++ b/src/ArrayList.php
@@ -49,29 +49,7 @@ class ArrayList extends AbstractList {
 		
 		return $this;
 	}
-	
-	/**
-	 * Returns the element at the given index (or nothing if the index isn't present)
-	 * 
-	 * @param int $index
-	 * @return mixed
-	 */
-	public function get($index) {
-		if (isset($this->collection[$index])) {
-			return $this->collection[$index];
-		}
-	}
 
-	/**
-	 * Returns the index of the given element or FALSE if the element can't be found
-	 * 
-	 * @param mixed $element
-	 * @return int the index for the given element
-	 */
-	public function indexOf($element) {
-		return array_search($element, $this->collection, true);
-	}
-	
 	/**
 	 * Removes an element from the list
 	 * 

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -100,4 +100,22 @@ class SetTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assertEquals(2, $set->size());
     }
+
+    public function testIndexOf() {
+        $item1 = 'item 1';
+        $item2 = 'item 2';
+        $item3 = 'item 3';
+        $items = [$item1, $item2, $item3];
+
+        $set = new Set($items);
+
+        $this->assertEquals(0, $set->indexOf($item1));
+        $this->assertEquals(1, $set->indexOf($item2));
+        $this->assertEquals(2, $set->indexOf($item3));
+        $this->assertFalse($set->indexOf('item4'));
+
+        $this->assertEquals($item1, $set->get(0));
+        $this->assertEquals($item2, $set->get(1));
+        $this->assertEquals($item3, $set->get(2));
+    }
 }


### PR DESCRIPTION
Move `get` and `indexOf` methods from ArrayList to AbstractList
class, so that they are accessible also in Set class.

Very useful in refactoring Propel3 Relation class :smile: 